### PR TITLE
Add *.d.tmp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ Makefile.save
 *.bak
 cscope.*
 *.d
+*.d.tmp
 pod2htmd.tmp
 
 # Windows manifest files


### PR DESCRIPTION
These are temporary files generated by the build process that should not
be checked in.

Reviewed-by: Richard Levitte <levitte@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/11122)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
