### PR TITLE
Introduce the provider property

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -562,12 +562,9 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
 int ossl_property_parse_init(OPENSSL_CTX *ctx)
 {
     static const char *const predefined_names[] = {
-        "default",      /* Being provided by the default built-in provider */
-        "legacy",       /* Provided by the legacy provider */
-        "provider",     /* Name of provider (default, fips) */
+        "provider",     /* Name of provider (default, legacy, fips) */
         "version",      /* Version number of this provider */
-        "fips",         /* FIPS supporting provider */
-        "engine",       /* An old style engine masquerading as a provider */
+        "fips",         /* FIPS validated or FIPS supporting algorithm */
         "format",       /* output format for serializers */
         "type",         /* output type for serializers */
     };

--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -16,9 +16,9 @@ properties, to be used with EVP_MAC_fetch():
 
 =over 4
 
-=item "BLAKE2BMAC", "default=yes"
+=item "BLAKE2BMAC", "provider=default"
 
-=item "BLAKE2SMAC", "default=yes"
+=item "BLAKE2SMAC", "provider=default"
 
 =back
 

--- a/doc/man7/EVP_MAC-CMAC.pod
+++ b/doc/man7/EVP_MAC-CMAC.pod
@@ -15,7 +15,7 @@ used with EVP_MAC_fetch():
 
 =over 4
 
-=item "CMAC", "default=yes"
+=item "CMAC", "provider=default" or "provider=fips"
 
 =back
 

--- a/doc/man7/EVP_MAC-GMAC.pod
+++ b/doc/man7/EVP_MAC-GMAC.pod
@@ -15,7 +15,7 @@ used with EVP_MAC_fetch():
 
 =over 4
 
-=item "GMAC", "default=yes"
+=item "GMAC", "provider=default" or "provider=fips"
 
 =back
 

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -15,7 +15,7 @@ used with EVP_MAC_fetch():
 
 =over 4
 
-=item "HMAC", "default=yes"
+=item "HMAC", "provider=default" or "provider=fips"
 
 =back
 

--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -16,9 +16,9 @@ properties, to be used with EVP_MAC_fetch():
 
 =over 4
 
-=item "KMAC-128", "default=yes"
+=item "KMAC-128", "provider=default" or "provider=fips"
 
-=item "KMAC-256", "default=yes"
+=item "KMAC-256", "provider=default" or "provider=fips"
 
 =back
 

--- a/doc/man7/EVP_MAC-Poly1305.pod
+++ b/doc/man7/EVP_MAC-Poly1305.pod
@@ -15,7 +15,7 @@ used with EVP_MAC_fetch():
 
 =over 4
 
-=item "POLY1305", "default=yes"
+=item "POLY1305", "provider=default"
 
 =back
 

--- a/doc/man7/EVP_MAC-Siphash.pod
+++ b/doc/man7/EVP_MAC-Siphash.pod
@@ -15,7 +15,7 @@ used with EVP_MAC_fetch():
 
 =over 4
 
-=item "SIPHASH", "default=yes"
+=item "SIPHASH", "provider=default"
 
 =back
 

--- a/doc/man7/property.pod
+++ b/doc/man7/property.pod
@@ -52,15 +52,15 @@ The full syntax for property definitions appears below.
 
 Each implementation of an algorithm can define any number of
 properties.
-For example, the default provider defines the property I<default=yes>
+For example, the default provider defines the property I<provider=default>
 for all of its algorithms.
-Likewise, the FIPS provider defines I<fips=yes> and the legacy provider
-defines I<legacy=yes> for all of their algorithms.
+Likewise, OpenSSL's FIPS provider defines I<provider=fips> and the legacy
+provider defines I<provider=legacy> for all of their algorithms.
 
 =head2 Queries
 
 A I<property query clause> is a single conditional test.
-For example, "fips=yes", "default!=yes" or "?iteration.count!=3".
+For example, "fips=yes", "provider!=default" or "?iteration.count!=3".
 The first two represent mandatory clauses, such clauses B<must> match
 for any algorithm to even be under consideration.
 The third clause represents an optional clause.
@@ -117,8 +117,8 @@ Ordering of optional clauses is not significant.
 =head2 Shortcut
 
 In order to permit a more concise expression of boolean properties, there
-is one short cut: a property name alone (e.g. "default") is
-exactly equivalent to "default=yes" in both definitions and queries.
+is one short cut: a property name alone (e.g. "my.property") is
+exactly equivalent to "my.property=yes" in both definitions and queries.
 
 =head2 Global and Local
 

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -260,8 +260,12 @@ algorithm identifier to the appropriate fetching function.
 
 The default provider is built in as part of the F<libcrypto> library.
 Should it be needed (if other providers are loaded and offer
-implementations of the same algorithms), the property "default=yes"
-can be used as a search criterion for these implementations.
+implementations of the same algorithms), the property "provider=default"
+can be used as a search criterion for these implementations. Some
+non-cryptographic algorithms (such as serializers for loading keys and
+parameters from files) are not FIPS algorithm implementations in themselves but
+support algorithms from the FIPS provider and are allowed for use in "FIPS
+mode". The property "fips=yes" can be used to select such algorithms.
 
 =head2 FIPS provider
 
@@ -269,8 +273,10 @@ The FIPS provider is a dynamically loadable module, and must therefore
 be loaded explicitly, either in code or through OpenSSL configuration
 (see L<config(5)>).
 Should it be needed (if other providers are loaded and offer
-implementations of the same algorithms), the property "fips=yes" can
-be used as a search criterion for these implementations.
+implementations of the same algorithms), the property "provider=fips" can
+be used as a search criterion for these implementations. All algorithm
+implementations in the FIPS provider can also be selected with the property
+"fips=yes".
 
 =head2 Legacy provider
 
@@ -278,7 +284,7 @@ The legacy provider is a dynamically loadable module, and must therefore
 be loaded explicitly, either in code or through OpenSSL configuration
 (see L<config(5)>).
 Should it be needed (if other providers are loaded and offer
-implementations of the same algorithms), the property "legacy=yes" can be
+implementations of the same algorithms), the property "provider=legacy" can be
 used as a search criterion for these implementations.
 
 =head1 EXAMPLES
@@ -300,21 +306,21 @@ Fetch any available implementation of AES-128-CBC in the default context:
 Fetch an implementation of SHA2-256 from the default provider in the default
 context:
 
- EVP_MD *md = EVP_MD_fetch(NULL, "SHA2-256", "default=yes");
+ EVP_MD *md = EVP_MD_fetch(NULL, "SHA2-256", "provider=default");
  ...
  EVP_MD_meth_free(md);
 
 Fetch an implementation of SHA2-256 that is not from the default provider in the
 default context:
 
- EVP_MD *md = EVP_MD_fetch(NULL, "SHA2-256", "default=no");
+ EVP_MD *md = EVP_MD_fetch(NULL, "SHA2-256", "provider!=default");
  ...
  EVP_MD_meth_free(md);
 
 Fetch an implementation of SHA2-256 from the default provider in the specified
 context:
 
- EVP_MD *md = EVP_MD_fetch(ctx, "SHA2-256", "default=yes");
+ EVP_MD *md = EVP_MD_fetch(ctx, "SHA2-256", "provider=default");
  ...
  EVP_MD_meth_free(md);
 
@@ -324,11 +330,11 @@ implementation of WHIRLPOOL from it:
  /* This only needs to be done once - usually at application start up */
  OSSL_PROVIDER *legacy = OSSL_PROVIDER_load(NULL, "legacy");
 
- EVP_MD *md = EVP_MD_fetch(NULL, "WHIRLPOOL", "legacy=yes");
+ EVP_MD *md = EVP_MD_fetch(NULL, "WHIRLPOOL", "provider=legacy");
  ...
  EVP_MD_meth_free(md);
 
-Note that in the above example the property string "legacy=yes" is optional
+Note that in the above example the property string "provider=legacy" is optional
 since, assuming no other providers have been loaded, the only implementation of
 the "whirlpool" algorithm is in the "legacy" provider. Also note that the
 default provider should be explicitly loaded if it is required in addition to

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -20,7 +20,7 @@
 #include "prov/provider_util.h"
 #include "internal/nelem.h"
 
-#define ALGC(NAMES, FUNC, CHECK) { { NAMES, "default=yes", FUNC }, CHECK }
+#define ALGC(NAMES, FUNC, CHECK) { { NAMES, "provider=default", FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
 /* Functions provided by the core */
@@ -86,32 +86,32 @@ static int deflt_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
  */
 static const OSSL_ALGORITHM deflt_digests[] = {
     /* Our primary name:NIST name[:our older names] */
-    { "SHA1:SHA-1", "default=yes", sha1_functions },
-    { "SHA2-224:SHA-224:SHA224", "default=yes", sha224_functions },
-    { "SHA2-256:SHA-256:SHA256", "default=yes", sha256_functions },
-    { "SHA2-384:SHA-384:SHA384", "default=yes", sha384_functions },
-    { "SHA2-512:SHA-512:SHA512", "default=yes", sha512_functions },
-    { "SHA2-512/224:SHA-512/224:SHA512-224", "default=yes",
+    { "SHA1:SHA-1", "provider=default", sha1_functions },
+    { "SHA2-224:SHA-224:SHA224", "provider=default", sha224_functions },
+    { "SHA2-256:SHA-256:SHA256", "provider=default", sha256_functions },
+    { "SHA2-384:SHA-384:SHA384", "provider=default", sha384_functions },
+    { "SHA2-512:SHA-512:SHA512", "provider=default", sha512_functions },
+    { "SHA2-512/224:SHA-512/224:SHA512-224", "provider=default",
       sha512_224_functions },
-    { "SHA2-512/256:SHA-512/256:SHA512-256", "default=yes",
+    { "SHA2-512/256:SHA-512/256:SHA512-256", "provider=default",
       sha512_256_functions },
 
     /* We agree with NIST here, so one name only */
-    { "SHA3-224", "default=yes", sha3_224_functions },
-    { "SHA3-256", "default=yes", sha3_256_functions },
-    { "SHA3-384", "default=yes", sha3_384_functions },
-    { "SHA3-512", "default=yes", sha3_512_functions },
+    { "SHA3-224", "provider=default", sha3_224_functions },
+    { "SHA3-256", "provider=default", sha3_256_functions },
+    { "SHA3-384", "provider=default", sha3_384_functions },
+    { "SHA3-512", "provider=default", sha3_512_functions },
 
     /*
      * KECCAK-KMAC-128 and KECCAK-KMAC-256 as hashes are mostly useful for
      * the KMAC-128 and KMAC-256.
      */
-    { "KECCAK-KMAC-128:KECCAK-KMAC128", "default=yes", keccak_kmac_128_functions },
-    { "KECCAK-KMAC-256:KECCAK-KMAC256", "default=yes", keccak_kmac_256_functions },
+    { "KECCAK-KMAC-128:KECCAK-KMAC128", "provider=default", keccak_kmac_128_functions },
+    { "KECCAK-KMAC-256:KECCAK-KMAC256", "provider=default", keccak_kmac_256_functions },
 
     /* Our primary name:NIST name */
-    { "SHAKE-128:SHAKE128", "default=yes", shake_128_functions },
-    { "SHAKE-256:SHAKE256", "default=yes", shake_256_functions },
+    { "SHAKE-128:SHAKE128", "provider=default", shake_128_functions },
+    { "SHAKE-256:SHAKE256", "provider=default", shake_256_functions },
 
 #ifndef OPENSSL_NO_BLAKE2
     /*
@@ -121,17 +121,17 @@ static const OSSL_ALGORITHM deflt_digests[] = {
      * If we assume that "2b" and "2s" are versions, that pattern
      * fits with ours.  We also add our historical names.
      */
-    { "BLAKE2S-256:BLAKE2s256", "default=yes", blake2s256_functions },
-    { "BLAKE2B-512:BLAKE2b512", "default=yes", blake2b512_functions },
+    { "BLAKE2S-256:BLAKE2s256", "provider=default", blake2s256_functions },
+    { "BLAKE2B-512:BLAKE2b512", "provider=default", blake2b512_functions },
 #endif /* OPENSSL_NO_BLAKE2 */
 
 #ifndef OPENSSL_NO_SM3
-    { "SM3", "default=yes", sm3_functions },
+    { "SM3", "provider=default", sm3_functions },
 #endif /* OPENSSL_NO_SM3 */
 
 #ifndef OPENSSL_NO_MD5
-    { "MD5", "default=yes", md5_functions },
-    { "MD5-SHA1", "default=yes", md5_sha1_functions },
+    { "MD5", "provider=default", md5_functions },
+    { "MD5-SHA1", "provider=default", md5_sha1_functions },
 #endif /* OPENSSL_NO_MD5 */
 
     { NULL, NULL, NULL }
@@ -331,136 +331,141 @@ static OSSL_ALGORITHM exported_ciphers[OSSL_NELEM(deflt_ciphers)];
 
 static const OSSL_ALGORITHM deflt_macs[] = {
 #ifndef OPENSSL_NO_BLAKE2
-    { "BLAKE2BMAC", "default=yes", blake2bmac_functions },
-    { "BLAKE2SMAC", "default=yes", blake2smac_functions },
+    { "BLAKE2BMAC", "provider=default", blake2bmac_functions },
+    { "BLAKE2SMAC", "provider=default", blake2smac_functions },
 #endif
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "default=yes", cmac_functions },
+    { "CMAC", "provider=default", cmac_functions },
 #endif
-    { "GMAC", "default=yes", gmac_functions },
-    { "HMAC", "default=yes", hmac_functions },
-    { "KMAC-128:KMAC128", "default=yes", kmac128_functions },
-    { "KMAC-256:KMAC256", "default=yes", kmac256_functions },
+    { "GMAC", "provider=default", gmac_functions },
+    { "HMAC", "provider=default", hmac_functions },
+    { "KMAC-128:KMAC128", "provider=default", kmac128_functions },
+    { "KMAC-256:KMAC256", "provider=default", kmac256_functions },
 #ifndef OPENSSL_NO_SIPHASH
-    { "SIPHASH", "default=yes", siphash_functions },
+    { "SIPHASH", "provider=default", siphash_functions },
 #endif
 #ifndef OPENSSL_NO_POLY1305
-    { "POLY1305", "default=yes", poly1305_functions },
+    { "POLY1305", "provider=default", poly1305_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_kdfs[] = {
-    { "HKDF", "default=yes", kdf_hkdf_functions },
-    { "SSKDF", "default=yes", kdf_sskdf_functions },
-    { "PBKDF2", "default=yes", kdf_pbkdf2_functions },
-    { "SSHKDF", "default=yes", kdf_sshkdf_functions },
-    { "X963KDF", "default=yes", kdf_x963_kdf_functions },
-    { "TLS1-PRF", "default=yes", kdf_tls1_prf_functions },
-    { "KBKDF", "default=yes", kdf_kbkdf_functions },
+    { "HKDF", "provider=default", kdf_hkdf_functions },
+    { "SSKDF", "provider=default", kdf_sskdf_functions },
+    { "PBKDF2", "provider=default", kdf_pbkdf2_functions },
+    { "SSHKDF", "provider=default", kdf_sshkdf_functions },
+    { "X963KDF", "provider=default", kdf_x963_kdf_functions },
+    { "TLS1-PRF", "provider=default", kdf_tls1_prf_functions },
+    { "KBKDF", "provider=default", kdf_kbkdf_functions },
 #ifndef OPENSSL_NO_CMS
-    { "X942KDF", "default=yes", kdf_x942_kdf_functions },
+    { "X942KDF", "provider=default", kdf_x942_kdf_functions },
 #endif
 #ifndef OPENSSL_NO_SCRYPT
-    { "SCRYPT:id-scrypt", "default=yes", kdf_scrypt_functions },
+    { "SCRYPT:id-scrypt", "provider=default", kdf_scrypt_functions },
 #endif
-    { "KRB5KDF", "default=yes", kdf_krb5kdf_functions },
+    { "KRB5KDF", "provider=default", kdf_krb5kdf_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_keyexch[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "default=yes", dh_keyexch_functions },
+    { "DH:dhKeyAgreement", "provider=default", dh_keyexch_functions },
 #endif
 #ifndef OPENSSL_NO_EC
-    { "ECDH:id-ecPublicKey", "default=yes", ecdh_keyexch_functions },
-    { "X25519", "default=yes", x25519_keyexch_functions },
-    { "X448", "default=yes", x448_keyexch_functions },
+    { "ECDH:id-ecPublicKey", "provider=default", ecdh_keyexch_functions },
+    { "X25519", "provider=default", x25519_keyexch_functions },
+    { "X448", "provider=default", x448_keyexch_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_signature[] = {
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "default=yes", dsa_signature_functions },
+    { "DSA:dsaEncryption", "provider=default", dsa_signature_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_asym_cipher[] = {
-    { "RSA:rsaEncryption", "default=yes", rsa_asym_cipher_functions },
+    { "RSA:rsaEncryption", "provider=default", rsa_asym_cipher_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "default=yes", dh_keymgmt_functions },
+    { "DH:dhKeyAgreement", "provider=default", dh_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "default=yes", dsa_keymgmt_functions },
+    { "DSA:dsaEncryption", "provider=default", dsa_keymgmt_functions },
 #endif
-    { "RSA:rsaEncryption", "default=yes", rsa_keymgmt_functions },
+    { "RSA:rsaEncryption", "provider=default", rsa_keymgmt_functions },
 #ifndef OPENSSL_NO_EC
-    { "EC:id-ecPublicKey", "default=yes", ec_keymgmt_functions },
-    { "X25519", "default=yes", x25519_keymgmt_functions },
-    { "X448", "default=yes", x448_keymgmt_functions },
+    { "EC:id-ecPublicKey", "provider=default", ec_keymgmt_functions },
+    { "X25519", "provider=default", x25519_keymgmt_functions },
+    { "X448", "provider=default", x448_keymgmt_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
+/*
+ * Unlike most algorithms in the default provider, the serializers are allowed
+ * for use in FIPS mode because they are not FIPS relevant, and therefore have
+ * the "fips=yes" property.
+ */
 static const OSSL_ALGORITHM deflt_serializer[] = {
-    { "RSA", "default=yes,format=text,type=private",
+    { "RSA", "provider=default,fips=yes,format=text,type=private",
       rsa_priv_text_serializer_functions },
-    { "RSA", "default=yes,format=text,type=public",
+    { "RSA", "provider=default,fips=yes,format=text,type=public",
       rsa_pub_text_serializer_functions },
-    { "RSA", "default=yes,format=der,type=private",
+    { "RSA", "provider=default,fips=yes,format=der,type=private",
       rsa_priv_der_serializer_functions },
-    { "RSA", "default=yes,format=der,type=public",
+    { "RSA", "provider=default,fips=yes,format=der,type=public",
       rsa_pub_der_serializer_functions },
-    { "RSA", "default=yes,format=pem,type=private",
+    { "RSA", "provider=default,fips=yes,format=pem,type=private",
       rsa_priv_pem_serializer_functions },
-    { "RSA", "default=yes,format=pem,type=public",
+    { "RSA", "provider=default,fips=yes,format=pem,type=public",
       rsa_pub_pem_serializer_functions },
 
 #ifndef OPENSSL_NO_DH
-    { "DH", "default=yes,format=text,type=private",
+    { "DH", "provider=default,fips=yes,format=text,type=private",
       dh_priv_text_serializer_functions },
-    { "DH", "default=yes,format=text,type=public",
+    { "DH", "provider=default,fips=yes,format=text,type=public",
       dh_pub_text_serializer_functions },
-    { "DH", "default=yes,format=text,type=parameters",
+    { "DH", "provider=default,fips=yes,format=text,type=parameters",
       dh_param_text_serializer_functions },
-    { "DH", "default=yes,format=der,type=private",
+    { "DH", "provider=default,fips=yes,format=der,type=private",
       dh_priv_der_serializer_functions },
-    { "DH", "default=yes,format=der,type=public",
+    { "DH", "provider=default,fips=yes,format=der,type=public",
       dh_pub_der_serializer_functions },
-    { "DH", "default=yes,format=der,type=parameters",
+    { "DH", "provider=default,fips=yes,format=der,type=parameters",
       dh_param_der_serializer_functions },
-    { "DH", "default=yes,format=pem,type=private",
+    { "DH", "provider=default,fips=yes,format=pem,type=private",
       dh_priv_pem_serializer_functions },
-    { "DH", "default=yes,format=pem,type=public",
+    { "DH", "provider=default,fips=yes,format=pem,type=public",
       dh_pub_pem_serializer_functions },
-    { "DH", "default=yes,format=pem,type=parameters",
+    { "DH", "provider=default,fips=yes,format=pem,type=parameters",
       dh_param_pem_serializer_functions },
 #endif
 
 #ifndef OPENSSL_NO_DSA
-    { "DSA", "default=yes,format=text,type=private",
+    { "DSA", "provider=default,fips=yes,format=text,type=private",
       dsa_priv_text_serializer_functions },
-    { "DSA", "default=yes,format=text,type=public",
+    { "DSA", "provider=default,fips=yes,format=text,type=public",
       dsa_pub_text_serializer_functions },
-    { "DSA", "default=yes,format=text,type=parameters",
+    { "DSA", "provider=default,fips=yes,format=text,type=parameters",
       dsa_param_text_serializer_functions },
-    { "DSA", "default=yes,format=der,type=private",
+    { "DSA", "provider=default,fips=yes,format=der,type=private",
       dsa_priv_der_serializer_functions },
-    { "DSA", "default=yes,format=der,type=public",
+    { "DSA", "provider=default,fips=yes,format=der,type=public",
       dsa_pub_der_serializer_functions },
-    { "DSA", "default=yes,format=der,type=parameters",
+    { "DSA", "provider=default,fips=yes,format=der,type=parameters",
       dsa_param_der_serializer_functions },
-    { "DSA", "default=yes,format=pem,type=private",
+    { "DSA", "provider=default,fips=yes,format=pem,type=private",
       dsa_priv_pem_serializer_functions },
-    { "DSA", "default=yes,format=pem,type=public",
+    { "DSA", "provider=default,fips=yes,format=pem,type=public",
       dsa_pub_pem_serializer_functions },
-    { "DSA", "default=yes,format=pem,type=parameters",
+    { "DSA", "provider=default,fips=yes,format=pem,type=parameters",
       dsa_param_pem_serializer_functions },
 #endif
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -34,7 +34,7 @@
 #include "prov/provider_util.h"
 #include "self_test.h"
 
-#define ALGC(NAMES, FUNC, CHECK) { { NAMES, "fips=yes", FUNC }, CHECK }
+#define ALGC(NAMES, FUNC, CHECK) { { NAMES, "provider=fips,fips=yes", FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
 extern OSSL_core_thread_start_fn *c_thread_start;
@@ -702,27 +702,27 @@ const char *ossl_prov_util_nid_to_name(int nid)
  */
 static const OSSL_ALGORITHM fips_digests[] = {
     /* Our primary name:NiST name[:our older names] */
-    { "SHA1:SHA-1", "fips=yes", sha1_functions },
-    { "SHA2-224:SHA-224:SHA224", "fips=yes", sha224_functions },
-    { "SHA2-256:SHA-256:SHA256", "fips=yes", sha256_functions },
-    { "SHA2-384:SHA-384:SHA384", "fips=yes", sha384_functions },
-    { "SHA2-512:SHA-512:SHA512", "fips=yes", sha512_functions },
-    { "SHA2-512/224:SHA-512/224:SHA512-224", "fips=yes",
+    { "SHA1:SHA-1", "provider=fips,fips=yes", sha1_functions },
+    { "SHA2-224:SHA-224:SHA224", "provider=fips,fips=yes", sha224_functions },
+    { "SHA2-256:SHA-256:SHA256", "provider=fips,fips=yes", sha256_functions },
+    { "SHA2-384:SHA-384:SHA384", "provider=fips,fips=yes", sha384_functions },
+    { "SHA2-512:SHA-512:SHA512", "provider=fips,fips=yes", sha512_functions },
+    { "SHA2-512/224:SHA-512/224:SHA512-224", "provider=fips,fips=yes",
       sha512_224_functions },
-    { "SHA2-512/256:SHA-512/256:SHA512-256", "fips=yes",
+    { "SHA2-512/256:SHA-512/256:SHA512-256", "provider=fips,fips=yes",
       sha512_256_functions },
 
     /* We agree with NIST here, so one name only */
-    { "SHA3-224", "fips=yes", sha3_224_functions },
-    { "SHA3-256", "fips=yes", sha3_256_functions },
-    { "SHA3-384", "fips=yes", sha3_384_functions },
-    { "SHA3-512", "fips=yes", sha3_512_functions },
+    { "SHA3-224", "provider=fips,fips=yes", sha3_224_functions },
+    { "SHA3-256", "provider=fips,fips=yes", sha3_256_functions },
+    { "SHA3-384", "provider=fips,fips=yes", sha3_384_functions },
+    { "SHA3-512", "provider=fips,fips=yes", sha3_512_functions },
     /*
      * KECCAK-KMAC-128 and KECCAK-KMAC-256 as hashes are mostly useful for
      * KMAC128 and KMAC256.
      */
-    { "KECCAK-KMAC-128:KECCAK-KMAC128", "fips=yes", keccak_kmac_128_functions },
-    { "KECCAK-KMAC-256:KECCAK-KMAC256", "fips=yes", keccak_kmac_256_functions },
+    { "KECCAK-KMAC-128:KECCAK-KMAC128", "provider=fips,fips=yes", keccak_kmac_128_functions },
+    { "KECCAK-KMAC-256:KECCAK-KMAC256", "provider=fips,fips=yes", keccak_kmac_256_functions },
 
     { NULL, NULL, NULL }
 };
@@ -773,51 +773,51 @@ static OSSL_ALGORITHM exported_fips_ciphers[OSSL_NELEM(fips_ciphers)];
 
 static const OSSL_ALGORITHM fips_macs[] = {
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "fips=yes", cmac_functions },
+    { "CMAC", "provider=fips,fips=yes", cmac_functions },
 #endif
-    { "GMAC", "fips=yes", gmac_functions },
-    { "HMAC", "fips=yes", hmac_functions },
-    { "KMAC-128:KMAC128", "fips=yes", kmac128_functions },
-    { "KMAC-256:KMAC256", "fips=yes", kmac256_functions },
+    { "GMAC", "provider=fips,fips=yes", gmac_functions },
+    { "HMAC", "provider=fips,fips=yes", hmac_functions },
+    { "KMAC-128:KMAC128", "provider=fips,fips=yes", kmac128_functions },
+    { "KMAC-256:KMAC256", "provider=fips,fips=yes", kmac256_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_kdfs[] = {
-    { "HKDF", "fips=yes", kdf_hkdf_functions },
-    { "SSKDF", "fips=yes", kdf_sskdf_functions },
-    { "PBKDF2", "fips=yes", kdf_pbkdf2_functions },
-    { "TLS1-PRF", "fips=yes", kdf_tls1_prf_functions },
-    { "KBKDF", "fips=yes", kdf_kbkdf_functions },
+    { "HKDF", "provider=fips,fips=yes", kdf_hkdf_functions },
+    { "SSKDF", "provider=fips,fips=yes", kdf_sskdf_functions },
+    { "PBKDF2", "provider=fips,fips=yes", kdf_pbkdf2_functions },
+    { "TLS1-PRF", "provider=fips,fips=yes", kdf_tls1_prf_functions },
+    { "KBKDF", "provider=fips,fips=yes", kdf_kbkdf_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_keyexch[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "fips=yes", dh_keyexch_functions },
+    { "DH:dhKeyAgreement", "provider=fips,fips=yes", dh_keyexch_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_signature[] = {
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "fips=yes", dsa_signature_functions },
+    { "DSA:dsaEncryption", "provider=fips,fips=yes", dsa_signature_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_asym_cipher[] = {
-    { "RSA:rsaEncryption", "fips=yes", rsa_asym_cipher_functions },
+    { "RSA:rsaEncryption", "provider=fips,fips=yes", rsa_asym_cipher_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "fips=yes", dh_keymgmt_functions },
+    { "DH:dhKeyAgreement", "provider=fips,fips=yes", dh_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA", "fips=yes", dsa_keymgmt_functions },
+    { "DSA", "provider=fips,fips=yes", dsa_keymgmt_functions },
 #endif
-    { "RSA:rsaEncryption", "default=yes", rsa_keymgmt_functions },
+    { "RSA:rsaEncryption", "provider=fips,fips=yes", rsa_keymgmt_functions },
     { NULL, NULL, NULL }
 };
 

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -56,23 +56,23 @@ static int legacy_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
 
 static const OSSL_ALGORITHM legacy_digests[] = {
 #ifndef OPENSSL_NO_MD2
-    { "MD2", "legacy=yes", md2_functions },
+    { "MD2", "provider=legacy", md2_functions },
 #endif
 
 #ifndef OPENSSL_NO_MD4
-    { "MD4", "legacy=yes", md4_functions },
+    { "MD4", "provider=legacy", md4_functions },
 #endif
 
 #ifndef OPENSSL_NO_MDC2
-    { "MDC2", "legacy=yes", mdc2_functions },
+    { "MDC2", "provider=legacy", mdc2_functions },
 #endif /* OPENSSL_NO_MDC2 */
 
 #ifndef OPENSSL_NO_WHIRLPOOL
-    { "WHIRLPOOL", "legacy=yes", wp_functions },
+    { "WHIRLPOOL", "provider=legacy", wp_functions },
 #endif /* OPENSSL_NO_WHIRLPOOL */
 
 #ifndef OPENSSL_NO_RMD160
-    { "RIPEMD-160:RIPEMD160:RIPEMD:RMD160", "legacy=yes", ripemd160_functions },
+    { "RIPEMD-160:RIPEMD160:RIPEMD:RMD160", "provider=legacy", ripemd160_functions },
 #endif /* OPENSSL_NO_RMD160 */
 
     { NULL, NULL, NULL }

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -40,7 +40,7 @@ const OPTIONS *test_get_options(void)
     static const OPTIONS test_options[] = {
         OPT_TEST_OPTIONS_WITH_EXTRA_USAGE("[provname...]\n"),
         { "type", OPT_ALG_FETCH_TYPE, 's', "The fetch type to test" },
-        { "property", OPT_FETCH_PROPERTY, 's', "The fetch property e.g. fips=yes" },
+        { "property", OPT_FETCH_PROPERTY, 's', "The fetch property e.g. provider=fips" },
         { "fetchfail", OPT_FETCH_FAILURE, '-', "fetch is expected to fail" },
         { "defaultctx", OPT_USE_DEFAULTCTX, '-',
           "Use the default context if this is set" },

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -33,16 +33,16 @@ my @testdata = (
       providers => [ 'default' ],
       tests  => [ { providers => [] },
                   { },
-                  { args      => [ '-property', 'default=yes' ],
-                    message   => 'using property "default=yes"' },
-                  { args      => [ '-property', 'fips=no' ],
-                    message   => 'using property "fips=no"' },
-                  { args      => [ '-property', 'default=no', '-fetchfail' ],
+                  { args      => [ '-property', 'provider=default' ],
+                    message   => 'using property "provider=default"' },
+                  { args      => [ '-property', 'provider!=fips' ],
+                    message   => 'using property "provider!=fips"' },
+                  { args      => [ '-property', 'provider!=default', '-fetchfail' ],
                     message   =>
-                        'using property "default=no" is expected to fail' },
-                  { args      => [ '-property', 'fips=yes', '-fetchfail' ],
+                        'using property "provider!=default" is expected to fail' },
+                  { args      => [ '-property', 'provider=fips', '-fetchfail' ],
                     message   =>
-                        'using property "fips=yes" is expected to fail' } ] }
+                        'using property "provider=fips" is expected to fail' } ] }
 );
 
 unless ($no_fips) {
@@ -60,28 +60,48 @@ unless ($no_fips) {
           providers => [ 'fips' ],
           tests     => [
               { args    => [ '-property', '' ] },
+              { args    => [ '-property', 'provider=fips' ],
+                message => 'using property "provider=fips"' },
+              { args    => [ '-property', 'provider!=default' ],
+                message => 'using property "provider!=default"' },
+              { args      => [ '-property', 'provider=default', '-fetchfail' ],
+                message   =>
+                    'using property "provider=default" is expected to fail' },
+              { args      => [ '-property', 'provider!=fips', '-fetchfail' ],
+                message   =>
+                    'using property "provider!=fips" is expected to fail' },
               { args    => [ '-property', 'fips=yes' ],
                 message => 'using property "fips=yes"' },
-              { args    => [ '-property', 'default=no' ],
-                message => 'using property "default = no"' },
-              { args      => [ '-property', 'default=yes', '-fetchfail' ],
-                message   =>
-                    'using property "default=yes" is expected to fail' },
-              { args      => [ '-property', 'fips=no', '-fetchfail' ],
-                message   =>
-                    'using property "fips=no" is expected to fail' } ] },
+              { args    => [ '-property', 'fips!=no' ],
+                message => 'using property "fips!=no"' },
+              { args    => [ '-property', '-fips' ],
+                message => 'using property "-fips"' },
+              { args    => [ '-property', 'fips=no', '-fetchfail' ],
+                message => 'using property "fips=no is expected to fail"' },
+              { args    => [ '-property', 'fips!=yes', '-fetchfail' ],
+                message => 'using property "fips!=yes is expected to fail"' } ] },
         { config    => srctop_file("test", "default-and-fips.cnf"),
           providers => [ 'default', 'fips' ],
           tests     => [
               { args    => [ '-property', '' ] },
-              { args      => [ '-property', 'default=no' ],
-                message   => 'using property "default=no"' },
-              { args      => [ '-property', 'default=yes' ],
-                message   => 'using property "default=yes"' },
-              { args      => [ '-property', 'fips=no' ],
-                message   => 'using property "fips=no"' },
-              { args      => [ '-property', 'fips=yes' ],
-                message   => 'using property "fips=yes"' } ] }
+              { args      => [ '-property', 'provider!=default' ],
+                message   => 'using property "provider!=default"' },
+              { args      => [ '-property', 'provider=default' ],
+                message   => 'using property "provider=default"' },
+              { args      => [ '-property', 'provider!=fips' ],
+                message   => 'using property "provider!=fips"' },
+              { args      => [ '-property', 'provider=fips' ],
+                message   => 'using property "provider=fips"' },
+              { args    => [ '-property', 'fips=yes' ],
+                message => 'using property "fips=yes"' },
+              { args    => [ '-property', 'fips!=no' ],
+                message => 'using property "fips!=no"' },
+              { args    => [ '-property', '-fips' ],
+                message => 'using property "-fips"' },
+              { args    => [ '-property', 'fips=no' ],
+                message => 'using property "fips=no"' },
+              { args    => [ '-property', 'fips!=yes' ],
+                message => 'using property "fips!=yes"' } ] },
     );
 }
 


### PR DESCRIPTION
Replace the properties default, fips and legacy with a single property
called "provider". So, for example, instead of writing "default=yes" to
get algorithms from the default provider you would instead write
"provider=default". We also have a new "fips" property to indicate that
an algorithm is compatible with FIPS mode. This applies to all the
algorithms in the FIPS provider, as well as any non-cryptographic
algorithms (currently only serializers).

Reviewed-by: Richard Levitte <levitte@openssl.org>
Reviewed-by: Tomas Mraz <tmraz@fedoraproject.org>
(Merged from https://github.com/openssl/openssl/pull/11097)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
