### PR TITLE
Fix default provider merge glitch

### DIFF
--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -384,7 +384,7 @@ static const OSSL_ALGORITHM deflt_signature[] = {
 #ifndef OPENSSL_NO_DSA
     { "DSA:dsaEncryption", "provider=default", dsa_signature_functions },
 #endif
-    { "RSA:rsaEncryption", "default=yes", rsa_signature_functions },
+    { "RSA:rsaEncryption", "provider=default", rsa_signature_functions },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
Property "default" no longer exists, replace "default=yes" with
"provider=default"

Reviewed-by: Paul Dale <paul.dale@oracle.com>
(Merged from https://github.com/openssl/openssl/pull/11150)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
