### PR TITLE
sslapitest: don't leak the SSL_CTX pair

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -655,7 +655,7 @@ end:
  * Very focused test to exercise a single case in the server-side state
  * machine, when the ChangeCipherState message needs to actually change
  * from one cipher to a different cipher (i.e., not changing from null
- * encryption to reall encryption).
+ * encryption to real encryption).
  */
 static int test_ccs_change_cipher(void)
 {
@@ -710,12 +710,8 @@ static int test_ccs_change_cipher(void)
      * Now create a fresh connection and try to renegotiate a different
      * cipher on it.
      */
-    if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
-                                       TLS_client_method(),
-                                       TLS1_VERSION, TLS1_2_VERSION,
-                                       &sctx, &cctx, cert, privkey))
-            || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                          NULL, NULL))
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL))
             || !TEST_true(SSL_set_cipher_list(clientssl, "AES128-GCM-SHA256"))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))


### PR DESCRIPTION
We have no need for a new set of SSL_CTXs in test_ccs_change_cipher(), so
just keep using the original ones.  Also, fix a typo in a comment.

[extended tests]

Reviewed-by: Matt Caswell <matt@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/11336)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
