### PR TITLE
Use RAND_bytes_ex in crypto/rsa

### DIFF
--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -169,4 +169,19 @@ int rsa_fips186_4_gen_prob_primes(RSA *rsa, BIGNUM *p1, BIGNUM *p2,
                                   const BIGNUM *Xq2, int nbits,
                                   const BIGNUM *e, BN_CTX *ctx, BN_GENCB *cb);
 
+int rsa_padding_add_SSLv23_with_libctx(OPENSSL_CTX *libctx, unsigned char *to,
+                                       int tlen, const unsigned char *from,
+                                       int flen);
+int rsa_padding_add_PKCS1_type_2_with_libctx(OPENSSL_CTX *libctx,
+                                             unsigned char *to, int tlen,
+                                             const unsigned char *from,
+                                             int flen);
+int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
+                                                unsigned char *to, int tlen,
+                                                const unsigned char *from,
+                                                int flen,
+                                                const unsigned char *param,
+                                                int plen, const EVP_MD *md,
+                                                const EVP_MD *mgf1md);
+
 #endif /* OSSL_CRYPTO_RSA_LOCAL_H */

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -40,8 +40,9 @@ int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
                                const unsigned char *from, int flen,
                                const unsigned char *param, int plen)
 {
-    return RSA_padding_add_PKCS1_OAEP_mgf1(to, tlen, from, flen,
-                                           param, plen, NULL, NULL);
+    return rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(NULL, to, tlen, from,
+                                                       flen, param, plen, NULL,
+                                                       NULL);
 }
 
 /*
@@ -51,10 +52,13 @@ int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
  * Step numbers are included here but not in the constant time inverse below
  * to avoid complicating an already difficult enough function.
  */
-int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
-                                    const unsigned char *from, int flen,
-                                    const unsigned char *param, int plen,
-                                    const EVP_MD *md, const EVP_MD *mgf1md)
+int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
+                                                unsigned char *to, int tlen,
+                                                const unsigned char *from,
+                                                int flen,
+                                                const unsigned char *param,
+                                                int plen, const EVP_MD *md,
+                                                const EVP_MD *mgf1md)
 {
     int rv = 0;
     int i, emlen = tlen - 1;
@@ -67,8 +71,7 @@ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     if (md == NULL)
         md = EVP_sha1();
 #else
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP_MGF1,
-               ERR_R_PASSED_NULL_PARAMETER);
+        RSAerr(0, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
 #endif
     if (mgf1md == NULL)
@@ -78,14 +81,12 @@ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
 
     /* step 2b: check KLen > nLen - 2 HLen - 2 */
     if (flen > emlen - 2 * mdlen - 1) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP_MGF1,
-               RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
+        RSAerr(0, RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
         return 0;
     }
 
     if (emlen < 2 * mdlen + 1) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP_MGF1,
-               RSA_R_KEY_SIZE_TOO_SMALL);
+        RSAerr(0, RSA_R_KEY_SIZE_TOO_SMALL);
         return 0;
     }
 
@@ -103,13 +104,13 @@ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     db[emlen - flen - mdlen - 1] = 0x01;
     memcpy(db + emlen - flen - mdlen, from, (unsigned int)flen);
     /* step 3d: generate random byte string */
-    if (RAND_bytes(seed, mdlen) <= 0)
+    if (RAND_bytes_ex(libctx, seed, mdlen) <= 0)
         goto err;
 
     dbmask_len = emlen - mdlen;
     dbmask = OPENSSL_malloc(dbmask_len);
     if (dbmask == NULL) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP_MGF1, ERR_R_MALLOC_FAILURE);
+        RSAerr(0, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
@@ -132,6 +133,16 @@ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     OPENSSL_cleanse(seedmask, sizeof(seedmask));
     OPENSSL_clear_free(dbmask, dbmask_len);
     return rv;
+}
+
+int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+                                    const unsigned char *from, int flen,
+                                    const unsigned char *param, int plen,
+                                    const EVP_MD *md, const EVP_MD *mgf1md)
+{
+    return rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(NULL, to, tlen, from,
+                                                       flen, param, plen, md,
+                                                       mgf1md);
 }
 
 int RSA_padding_check_PKCS1_OAEP(unsigned char *to, int tlen,

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -111,14 +111,18 @@ static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
 
     switch (padding) {
     case RSA_PKCS1_PADDING:
-        i = RSA_padding_add_PKCS1_type_2(buf, num, from, flen);
+        i = rsa_padding_add_PKCS1_type_2_with_libctx(rsa->libctx, buf, num,
+                                                     from, flen);
         break;
     case RSA_PKCS1_OAEP_PADDING:
-        i = RSA_padding_add_PKCS1_OAEP(buf, num, from, flen, NULL, 0);
+        i = rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(rsa->libctx, buf, num,
+                                                        from, flen, NULL, 0,
+                                                        NULL, NULL);
         break;
 #ifndef FIPS_MODE
     case RSA_SSLV23_PADDING:
-        i = RSA_padding_add_SSLv23(buf, num, from, flen);
+        i = rsa_padding_add_SSLv23_with_libctx(rsa->libctx, buf, num, from,
+                                               flen);
         break;
 #endif
     case RSA_NO_PADDING:

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -206,7 +206,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
                    ERR_R_MALLOC_FAILURE);
             goto err;
         }
-        if (RAND_bytes(salt, sLen) <= 0)
+        if (RAND_bytes_ex(rsa->libctx, salt, sLen) <= 0)
             goto err;
     }
     maskedDBLen = emLen - hLen - 1;

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -19,16 +19,17 @@
 #include <openssl/rsa.h>
 #include <openssl/rand.h>
 #include "internal/constant_time.h"
+#include "rsa_local.h"
 
-int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
-                           const unsigned char *from, int flen)
+int rsa_padding_add_SSLv23_with_libctx(OPENSSL_CTX *libctx, unsigned char *to,
+                                       int tlen, const unsigned char *from,
+                                       int flen)
 {
     int i, j;
     unsigned char *p;
 
     if (flen > (tlen - RSA_PKCS1_PADDING_SIZE)) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_SSLV23,
-               RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
+        RSAerr(0, RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
         return 0;
     }
 
@@ -40,12 +41,12 @@ int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
     /* pad out with non-zero random data */
     j = tlen - 3 - 8 - flen;
 
-    if (RAND_bytes(p, j) <= 0)
+    if (RAND_bytes_ex(libctx, p, j) <= 0)
         return 0;
     for (i = 0; i < j; i++) {
         if (*p == '\0')
             do {
-                if (RAND_bytes(p, 1) <= 0)
+                if (RAND_bytes_ex(libctx, p, 1) <= 0)
                     return 0;
             } while (*p == '\0');
         p++;
@@ -57,6 +58,12 @@ int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
 
     memcpy(p, from, (unsigned int)flen);
     return 1;
+}
+
+int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
+                           const unsigned char *from, int flen)
+{
+    return rsa_padding_add_SSLv23_with_libctx(NULL, to, tlen, from, flen);
 }
 
 /*

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -21,9 +21,10 @@ int rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
                         STACK_OF(BIGNUM_const) *exps,
                         STACK_OF(BIGNUM_const) *coeffs);
 
-int rsa_padding_check_PKCS1_type_2_TLS(unsigned char *to, size_t tlen,
-                                       const unsigned char *from, size_t flen,
-                                       int client_version, int alt_version);
+int rsa_padding_check_PKCS1_type_2_TLS(OPENSSL_CTX *ctx, unsigned char *to,
+                                       size_t tlen, const unsigned char *from,
+                                       size_t flen, int client_version,
+                                       int alt_version);
 
 int rsa_validate_public(const RSA *key);
 int rsa_validate_private(const RSA *key);

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -225,7 +225,8 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
                 ERR_raise(ERR_LIB_PROV, PROV_R_BAD_TLS_CLIENT_VERSION);
                 return 0;
             }
-            ret = rsa_padding_check_PKCS1_type_2_TLS(out, outsize,
+            ret = rsa_padding_check_PKCS1_type_2_TLS(prsactx->libctx, out,
+                                                     outsize,
                                                      tbuf, len,
                                                      prsactx->client_version,
                                                      prsactx->alt_version);


### PR DESCRIPTION
At various points in crypto/rsa we need to get random numbers. We should
ensure that we use the correct libctx when doing so.

Reviewed-by: Tomas Mraz <tmraz@fedoraproject.org>
(Merged from https://github.com/openssl/openssl/pull/11355)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
