### PR TITLE
ci: QEMU based cross compiled testing

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -7,50 +7,83 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The platform matrix specifies the package to be loaded by apt,
-        # then the cross compilation prefix and finally the configuration
-        # target.
+        # The platform matrix specifies:
+        #   arch: the architecture to build for, this defines the tool-chain
+        #         prefix {arch}- and the Debian compiler package gcc-{arch}
+        #         name.
+        #   libs: the Debian package for the necessary link/runtime libraries.
+        #   target: the OpenSSL configuration target to use, this is passed
+        #           directly to the config command line.
+        #   tests: omit this to run all the tests using QEMU, set it to "none"
+        #          to never run the tests, otherwise it's value is passed to
+        #          the "make test" command to allow selectiving disabling of
+        #          tests.
         platform: [
           {
-            package: gcc-aarch64-linux-gnu libc6-dev-arm64-cross,
-            cross: aarch64-linux-gnu-,
+            arch: aarch64-linux-gnu,
+            libs: libc6-dev-arm64-cross,
             target: linux-aarch64
           }, {
-            package: gcc-alpha-linux-gnu libc6.1-dev-alpha-cross,
-            cross: alpha-linux-gnu-,
+            arch: alpha-linux-gnu,
+            libs: libc6.1-dev-alpha-cross,
             target: linux-alpha-gcc
           }, {
-            package: gcc-arm-linux-gnueabi libc6-dev-armel-cross,
-            cross: arm-linux-gnueabi-,
-            target: linux-armv4
+            arch: arm-linux-gnueabi,
+            libs: libc6-dev-armel-cross,
+            target: linux-armv4,
+            tests: -test_includes -test_store -test_x509_store
           }, {
-            package: gcc-arm-linux-gnueabihf libc6-dev-armhf-cross,
-            cross: arm-linux-gnueabihf-,
-            target: linux-armv4
+            arch: arm-linux-gnueabihf,
+            libs: libc6-dev-armhf-cross,
+            target: linux-armv4,
+            tests: -test_includes -test_store -test_x509_store
           }, {
-            package: gcc-mips-linux-gnu libc6-dev-mips-cross,
-            cross: mips-linux-gnu-,
-            target: linux-mips32
+            arch: hppa-linux-gnu,
+            libs: libc6-dev-hppa-cross,
+            target: linux-generic32,
+            tests: none #-test_includes -test_store -test_x509_store
           }, {
-            package: gcc-mipsel-linux-gnu libc6-dev-mipsel-cross,
-            cross: mipsel-linux-gnu-,
-            target: linux-mips32
+            arch: m68k-linux-gnu,
+            libs: libc6-dev-m68k-cross,
+            target: linux-latomic no-asm,
+            tests: none #-test_includes -test_store -test_x509_store -test_includes
           }, {
-            package: gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross,
-            cross: powerpc64le-linux-gnu-,
+            arch: mips-linux-gnu,
+            libs: libc6-dev-mips-cross,
+            target: linux-mips32,
+            tests: none
+          }, {
+            arch: mips64-linux-gnuabi64,
+            libs: libc6-dev-mips64-cross,
+            target: linux64-mips64,
+            tests: none
+          }, {
+            arch: mipsel-linux-gnu,
+            libs: libc6-dev-mipsel-cross,
+            target: linux-mips32,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: powerpc64le-linux-gnu,
+            libs: libc6-dev-ppc64el-cross,
             target: linux-ppc64le
           }, {
-            package: gcc-riscv64-linux-gnu libc6-dev-riscv64-cross,
-            cross: riscv64-linux-gnu-,
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64
           }, {
-            package: gcc-s390x-linux-gnu libc6-dev-s390x-cross,
-            cross: s390x-linux-gnu-,
+            arch: s390x-linux-gnu,
+            libs: libc6-dev-s390x-cross,
             target: linux64-s390x
           }, {
-            package: gcc-sparc64-linux-gnu libc6-dev-sparc64-cross,
-            cross: sparc64-linux-gnu-,
-            target: linux64-sparcv9
+            arch: sh4-linux-gnu,
+            libs: libc6-dev-sh4-cross,
+            target: linux-latomic,
+            tests: -test_includes -test_store -test_x509_store -test_async
+          }, {
+            arch: sparc64-linux-gnu,
+            libs: libc6-dev-sparc64-cross,
+            target: linux64-sparcv9,
+            tests: none
           }
         ]
     runs-on: ubuntu-latest
@@ -58,9 +91,34 @@ jobs:
     - name: install packages
       run: |
         sudo apt-get update
-        sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install ${{ matrix.platform.package }}
+        sudo apt-get -yq --force-yes install \
+            gcc-${{ matrix.platform.arch }} \
+            ${{ matrix.platform.libs }}
     - uses: actions/checkout@v2
+
     - name: config
-      run: ./config --banner=Configured --strict-warnings enable-fips --cross-compile-prefix=${{ matrix.platform.cross }} ${{ matrix.platform.target }} && perl configdata.pm --dump
+      run: |
+        ./config --banner=Configured --strict-warnings enable-fips \
+                 --cross-compile-prefix=${{ matrix.platform.arch }}- \
+                 ${{ matrix.platform.target }}
+    - name: config dump
+      run: ./configdata.pm --dump
+
     - name: make
       run: make -s -j4
+
+    - name: install qemu
+      if: github.event_name == 'push' && matrix.platform.tests != 'none'
+      run: sudo apt-get -yq --force-yes install qemu-user
+
+    - name: make all tests
+      if: github.event_name == 'push' && matrix.platform.tests == ''
+      run: |
+        make test HARNESS_JOBS=${HARNESS_JOBS:-4} \
+                  QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
+    - name: make some tests
+      if: github.event_name == 'push' && matrix.platform.tests != 'none' && matrix.platform.tests != ''
+      run: |
+        make test HARNESS_JOBS=${HARNESS_JOBS:-4} \
+                  TESTS="${{ matrix.platform.tests }}" \
+                  QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}


### PR DESCRIPTION
With a little set up, Debian provides an ability to use QEMU to execute
programs compiled for other architectures. Using this, most of our cross
compilation CI builds can be executed.

This PR does this.

Reviewed-by: Tomas Mraz <tomas@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/16133)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
