### PR TITLE
Redefine getpid() -> _getpid() only for MSVC

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -27,12 +27,12 @@ typedef unsigned int u_int;
 #endif
 
 #ifdef _WIN32
-/*
- * With MSVC, certain POSIX functions have been renamed to have an underscore
- * prefix.
- */
 # include <process.h>
-# define getpid _getpid
+
+/* MSVC renamed some POSIX functions to have an underscore prefix. */
+# ifdef _MSC_VER
+#  define getpid _getpid
+# endif
 #endif
 
 #ifndef OPENSSL_NO_SOCK


### PR DESCRIPTION
This was introduced in 814b5133e for MSVC. C++Builder doesn't need it.

Reviewed-by: Paul Dale <pauli@openssl.org>
Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
(Merged from https://github.com/openssl/openssl/pull/16192)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
